### PR TITLE
Fix www-authenticate regex for harbor

### DIFF
--- a/nanolayer/utils/oci_registry.py
+++ b/nanolayer/utils/oci_registry.py
@@ -42,7 +42,7 @@ class OCIRegistry:
         resource: str
         path: str
 
-    WWW_AUTHENTICATE_REGEX = r'.*[Ww]ww-[Aa]uthenticate:\sBearer\srealm="([\w:/\.]+)",service="([\w:/\.]+)",scope="([\w:/\-,]+)".*'
+    WWW_AUTHENTICATE_REGEX = r'.*[Ww]ww-[Aa]uthenticate:\sBearer\srealm="([\w:/\.]+)",service="([\w:/\-\.]+)",scope="([\w:/\-,]+)".*'
 
     @staticmethod
     def parse_oci(oci_input: str) -> "OCIRegistry.ParsedOCIRef":


### PR DESCRIPTION
This commit adds "-" as a possible character in the service element of the www-authenticate header, because harbor uses "harbor-registry" as value for this element.